### PR TITLE
LPS-82333

### DIFF
--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1068,6 +1068,17 @@ public class LanguageImpl implements Language, Serializable {
 
 	@Override
 	public Locale getLocale(long groupId, String languageCode) {
+		try {
+			if (isInheritLocales(groupId)) {
+				return getLocale(languageCode);
+			}
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to check if group inherits locales");
+			}
+		}
+
 		Map<String, Locale> groupLanguageCodeLocalesMap =
 			_getGroupLanguageCodeLocalesMap(groupId);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82333
https://issues.liferay.com/browse/LPS-79309

Hey Matt,
The problem was due to sites which inherit locales not being updated when the global local list changed.  This is because we store the group locales in a map and only update it when the group locales are explicitly updated or the server is restarted.

This fix makes groups which inherit the locales gather locales from the companyLocaleBag instead, so they are never outdated.

Let me know if you have any questions, thanks!